### PR TITLE
Add `wuff-capi` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,3 +95,10 @@ dependencies = [
  "bytes",
  "flate2",
 ]
+
+[[package]]
+name = "wuff-capi"
+version = "0.1.0"
+dependencies = [
+ "wuff",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = ["wuff-capi"]
+
 [package]
 name = "wuff"
 version = "0.2.6"

--- a/wuff-capi/Cargo.toml
+++ b/wuff-capi/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "wuff-capi"
+version = "0.1.0"
+description = "C API for the wuff WOFF2 decoder, compatible with the woff2 C library's decoding API"
+authors = ["Nico Burns <nico@nicoburns.com>"]
+license = "MIT"
+repository = "https://github.com/nicoburns/wuff"
+documentation = "https://docs.rs/wuff-capi"
+keywords = ["font", "opentype", "truetype", "woff2", "ffi"]
+categories = ["parsing", "external-ffi-bindings"]
+readme = "README.md"
+edition = "2024"
+rust-version = "1.85"
+links = "woff2"
+include = [
+    "Cargo.toml",
+    "README.md",
+    "build.rs",
+    "src/*",
+    "include/*",
+]
+
+[dependencies]
+wuff = { version = "0.2.6", path = "..", default-features = false, features = ["brotli"] }

--- a/wuff-capi/README.md
+++ b/wuff-capi/README.md
@@ -1,8 +1,11 @@
 # wuff-capi
 
-C API for the [wuff](https://docs.rs/wuff) pure-Rust WOFF2 decoder, compatible
+C++ API for the [wuff](https://docs.rs/wuff) pure-Rust WOFF2 decoder, compatible
 with the decoding API of the [woff2](https://github.com/google/woff2) C++
 library.
+
+Note: only the *decoding* API (`woff2/decode.h` and `woff2/output.h`) is
+provided. The encoding API (`woff2/encode.h`) is not yet implemented.
 
 ## What this crate provides
 
@@ -12,17 +15,10 @@ library.
   - `wuff_woff2_decode` — decompresses a WOFF2 font into a newly-allocated
     buffer
   - `wuff_woff2_free` — frees a buffer returned by `wuff_woff2_decode`
-- C++ headers (in `include/woff2/`) that reimplement the woff2 library's
-  decoding API (`woff2::ComputeWOFF2FinalSize`, `woff2::ConvertWOFF2ToTTF`,
-  `woff2::WOFF2Out`, `woff2::WOFF2StringOut`, `woff2::WOFF2MemoryOut`) as
-  header-only wrappers around the C symbols above.
+- C++ headers (in `include/woff2`) that provide a drop-in replacement for the
+  C++ woff2 library's decoding API as header-only wrappers around the C symbols above.
 
-This makes the crate a drop-in replacement for the woff2 library for C/C++
-code that only uses its decoding API — for example the
-[ots](https://github.com/khaledhosny/ots) sanitiser as vendored by
-[fontsan](https://github.com/servo/fontsan).
-
-## Usage
+## Usage (from Rust)
 
 Add `wuff-capi` as a dependency of the crate whose build script compiles the
 C/C++ code that consumes the woff2 API. This crate sets `links = "woff2"`, and
@@ -40,5 +36,4 @@ cc::Build::new()
 
 The Rust symbols are linked automatically as part of the normal Rust build.
 
-Note: only the *decoding* API (`woff2/decode.h` and `woff2/output.h`) is
-provided. The encoding API (`woff2/encode.h`) is not.
+

--- a/wuff-capi/README.md
+++ b/wuff-capi/README.md
@@ -1,0 +1,44 @@
+# wuff-capi
+
+C API for the [wuff](https://docs.rs/wuff) pure-Rust WOFF2 decoder, compatible
+with the decoding API of the [woff2](https://github.com/google/woff2) C++
+library.
+
+## What this crate provides
+
+- `extern "C"` symbols exported from Rust:
+  - `wuff_woff2_compute_final_size` — reads the `totalSfntSize` field of a
+    WOFF2 header (equivalent to `woff2::ComputeWOFF2FinalSize`)
+  - `wuff_woff2_decode` — decompresses a WOFF2 font into a newly-allocated
+    buffer
+  - `wuff_woff2_free` — frees a buffer returned by `wuff_woff2_decode`
+- C++ headers (in `include/woff2/`) that reimplement the woff2 library's
+  decoding API (`woff2::ComputeWOFF2FinalSize`, `woff2::ConvertWOFF2ToTTF`,
+  `woff2::WOFF2Out`, `woff2::WOFF2StringOut`, `woff2::WOFF2MemoryOut`) as
+  header-only wrappers around the C symbols above.
+
+This makes the crate a drop-in replacement for the woff2 library for C/C++
+code that only uses its decoding API — for example the
+[ots](https://github.com/khaledhosny/ots) sanitiser as vendored by
+[fontsan](https://github.com/servo/fontsan).
+
+## Usage
+
+Add `wuff-capi` as a dependency of the crate whose build script compiles the
+C/C++ code that consumes the woff2 API. This crate sets `links = "woff2"`, and
+its build script exports the location of its headers, which is available in
+dependent build scripts as the `DEP_WOFF2_INCLUDE_DIR` environment variable:
+
+```rust
+// build.rs of a dependent crate
+let woff2_include_dir = std::env::var("DEP_WOFF2_INCLUDE_DIR").unwrap();
+cc::Build::new()
+    .cpp(true)
+    .include(woff2_include_dir)
+    // ...
+```
+
+The Rust symbols are linked automatically as part of the normal Rust build.
+
+Note: only the *decoding* API (`woff2/decode.h` and `woff2/output.h`) is
+provided. The encoding API (`woff2/encode.h`) is not.

--- a/wuff-capi/build.rs
+++ b/wuff-capi/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    // Expose the C/C++ headers to dependent crates as DEP_WOFF2_INCLUDE_DIR
+    // (the `links = "woff2"` key in Cargo.toml determines the WOFF2 part).
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    println!("cargo::metadata=include_dir={manifest_dir}/include");
+}

--- a/wuff-capi/include/woff2/decode.h
+++ b/wuff-capi/include/woff2/decode.h
@@ -1,0 +1,75 @@
+/* Copyright 2014 Google Inc. All Rights Reserved.
+
+   Distributed under MIT license.
+   See file LICENSE for detail or copy at https://opensource.org/licenses/MIT
+*/
+
+/* Library for converting WOFF2 format font files to their TTF versions.
+
+   This is a header-only reimplementation of the decoding API from the woff2
+   C++ library (https://github.com/google/woff2), provided by the wuff-capi
+   Rust crate. The `woff2` namespace functions below are implemented on top
+   of C symbols exported by the wuff-capi Rust library, which must be linked
+   into the final binary.
+*/
+
+#ifndef WOFF2_WOFF2_DEC_H_
+#define WOFF2_WOFF2_DEC_H_
+
+#include <stddef.h>
+#include <inttypes.h>
+#include <woff2/output.h>
+
+// Import public API from Rust library
+extern "C" {
+   // Compute the size of the final uncompressed font by reading the
+   // totalSfntSize field of the WOFF2 header, or 0 on error.
+   size_t wuff_woff2_compute_final_size(const uint8_t *data, size_t length);
+
+   // Decompress a WOFF2 font into a newly-allocated buffer.
+   //
+   // On success, returns  a pointer to the decompressed font and stores its length in *result_length.
+   // On failure, returns NULL and stores 0 in *result_length.
+   // The buffer must be freed with wuff_woff2_free.
+   uint8_t *wuff_woff2_decode(const uint8_t *data, size_t length, size_t *result_length);
+
+   // Free a buffer previously returned by wuff_woff2_decode.
+   // `length` must be the value stored in *result_length by that call.
+   void wuff_woff2_free(uint8_t *ptr, size_t length);
+}
+
+namespace woff2 {
+
+// Compute the size of the final uncompressed font, or 0 on error.
+size_t ComputeWOFF2FinalSize(const uint8_t *data, size_t length) {
+  return wuff_woff2_compute_final_size(data, length);
+}
+
+// Decompresses the font into out. Returns true on success.
+// Works even if WOFF2Header totalSfntSize is wrong.
+// Please prefer this API.
+bool ConvertWOFF2ToTTF(const uint8_t *data, size_t length,
+                       WOFF2Out* out) {
+  size_t result_length = 0;
+  uint8_t *result = wuff_woff2_decode(data, length, &result_length);
+  if (result == NULL) {
+    return false;
+  }
+  bool ok = out->Write(result, result_length);
+  wuff_woff2_free(result, result_length);
+  return ok;
+}
+
+// Decompresses the font into the target buffer. The result_length should
+// be the same as determined by ComputeFinalSize(). Returns true on successful
+// decompression.
+// DEPRECATED; please prefer the version that takes a WOFF2Out*
+bool ConvertWOFF2ToTTF(uint8_t *result, size_t result_length,
+                       const uint8_t *data, size_t length) {
+  WOFF2MemoryOut out(result, result_length);
+  return ConvertWOFF2ToTTF(data, length, &out);
+}
+
+} // namespace woff2
+
+#endif  // WOFF2_WOFF2_DEC_H_

--- a/wuff-capi/include/woff2/output.h
+++ b/wuff-capi/include/woff2/output.h
@@ -1,0 +1,136 @@
+/* Copyright 2016 Google Inc. All Rights Reserved.
+
+   Distributed under MIT license.
+   See file LICENSE for detail or copy at https://opensource.org/licenses/MIT
+*/
+
+/* Output buffer for WOFF2 decompression.
+
+   This is a header-only reimplementation of the output API from the woff2
+   C++ library (https://github.com/google/woff2), provided by the wuff-capi
+   Rust crate. The class definitions and semantics match the originals from
+   woff2/output.h and woff2_out.cc.
+*/
+
+#ifndef WOFF2_WOFF2_OUT_H_
+#define WOFF2_WOFF2_OUT_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <algorithm>
+#include <cstring>
+#include <memory>
+#include <string>
+
+namespace woff2 {
+
+// Suggested max size for output.
+const size_t kDefaultMaxSize = 30 * 1024 * 1024;
+
+/**
+ * Output interface for the woff2 decoding.
+ *
+ * Writes to arbitrary offsets are supported to facilitate updating offset
+ * table and checksums after tables are ready. Reading the current size is
+ * supported so a 'loca' table can be built up while writing glyphs.
+ *
+ * By default limits size to kDefaultMaxSize.
+ */
+class WOFF2Out {
+ public:
+  virtual ~WOFF2Out(void) {}
+
+  // Append n bytes of data from buf.
+  // Return true if all written, false otherwise.
+  virtual bool Write(const void *buf, size_t n) = 0;
+
+  // Write n bytes of data from buf at offset.
+  // Return true if all written, false otherwise.
+  virtual bool Write(const void *buf, size_t offset, size_t n) = 0;
+
+  virtual size_t Size() = 0;
+};
+
+/**
+ * Expanding memory block for woff2 out. By default limited to kDefaultMaxSize.
+ */
+class WOFF2StringOut : public WOFF2Out {
+ public:
+  // Create a writer that writes its data to buf.
+  // buf->size() will grow to at most max_size
+  // buf may be sized (e.g. using EstimateWOFF2FinalSize) or empty.
+  explicit WOFF2StringOut(std::string* buf)
+      : buf_(buf), max_size_(kDefaultMaxSize), offset_(0) {}
+
+  bool Write(const void *buf, size_t n) override {
+    return Write(buf, offset_, n);
+  }
+
+  bool Write(const void *buf, size_t offset, size_t n) override {
+    if (offset > max_size_ || n > max_size_ - offset) {
+      return false;
+    }
+    if (offset == buf_->size()) {
+      buf_->append(static_cast<const char*>(buf), n);
+    } else {
+      if (offset + n > buf_->size()) {
+        buf_->append(offset + n - buf_->size(), 0);
+      }
+      buf_->replace(offset, n, static_cast<const char*>(buf), n);
+    }
+    offset_ = std::max(offset_, offset + n);
+
+    return true;
+  }
+
+  size_t Size() override { return offset_; }
+  size_t MaxSize() { return max_size_; }
+
+  void SetMaxSize(size_t max_size) {
+    max_size_ = max_size;
+    if (offset_ > max_size_) {
+      offset_ = max_size_;
+    }
+  }
+
+ private:
+  std::string *buf_;
+  size_t max_size_;
+  size_t offset_;
+};
+
+/**
+ * Fixed memory block for woff2 out.
+ */
+class WOFF2MemoryOut : public WOFF2Out {
+ public:
+  // Create a writer that writes its data to buf.
+  WOFF2MemoryOut(uint8_t* buf, size_t buf_size)
+      : buf_(buf), buf_size_(buf_size), offset_(0) {}
+
+  bool Write(const void *buf, size_t n) override {
+    return Write(buf, offset_, n);
+  }
+
+  bool Write(const void *buf, size_t offset, size_t n) override {
+    if (offset > buf_size_ || n > buf_size_ - offset) {
+      return false;
+    }
+    std::memcpy(buf_ + offset, buf, n);
+    offset_ = std::max(offset_, offset + n);
+
+    return true;
+  }
+
+  size_t Size() override { return offset_; }
+
+ private:
+  uint8_t* buf_;
+  size_t buf_size_;
+  size_t offset_;
+};
+
+} // namespace woff2
+
+#endif  // WOFF2_WOFF2_OUT_H_

--- a/wuff-capi/src/lib.rs
+++ b/wuff-capi/src/lib.rs
@@ -1,0 +1,131 @@
+//! C API for the [wuff](https://docs.rs/wuff) WOFF2 decoder.
+//!
+//! This crate exposes `extern "C"` symbols wrapping wuff's WOFF2 decoder, plus
+//! (in its `include` directory) C++ headers (`woff2/decode.h` and
+//! `woff2/output.h`) which reimplement the decoding API of the
+//! [woff2](https://github.com/google/woff2) C++ library on top of those
+//! symbols. This allows the crate to be used as a drop-in replacement for the
+//! woff2 library by C/C++ code (such as the `ots` sanitiser) that consumes
+//! only its decoding API.
+//!
+//! Build scripts of dependent crates can locate the headers via the
+//! `DEP_WOFF2_INCLUDE_DIR` environment variable.
+
+use std::panic::catch_unwind;
+
+/// Compute the size of the final uncompressed font, or 0 on error.
+///
+/// This reads the `totalSfntSize` field of the WOFF2 header. It is the
+/// C equivalent of the woff2 library's `woff2::ComputeWOFF2FinalSize`.
+///
+/// # Safety
+///
+/// `data` must either be null (in which case 0 is returned) or point to
+/// `length` bytes of readable memory.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wuff_woff2_compute_final_size(data: *const u8, length: usize) -> usize {
+    if data.is_null() || length < 20 {
+        return 0;
+    }
+    let bytes = unsafe { std::slice::from_raw_parts(data, length) };
+    u32::from_be_bytes(bytes[16..20].try_into().unwrap()) as usize
+}
+
+/// Decompress a WOFF2 font into a newly-allocated buffer.
+///
+/// On success, returns a pointer to the decompressed font and stores its
+/// length in `*result_length`. The buffer must be freed by passing the
+/// returned pointer and length to [`wuff_woff2_free`].
+///
+/// On failure, returns null and stores 0 in `*result_length`.
+///
+/// # Safety
+///
+/// - `data` must either be null (in which case null is returned) or point to
+///   `length` bytes of readable memory.
+/// - `result_length` must be a valid pointer to a writable `size_t`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wuff_woff2_decode(
+    data: *const u8,
+    length: usize,
+    result_length: *mut usize,
+) -> *mut u8 {
+    unsafe { *result_length = 0 };
+    if data.is_null() {
+        return std::ptr::null_mut();
+    }
+    let bytes = unsafe { std::slice::from_raw_parts(data, length) };
+
+    // Catch panics: unwinding across an `extern "C"` boundary would abort.
+    let result = catch_unwind(|| wuff::decompress_woff2(bytes));
+    match result {
+        Ok(Ok(decompressed)) => {
+            let boxed: Box<[u8]> = decompressed.into_boxed_slice();
+            let len = boxed.len();
+            let ptr = Box::into_raw(boxed) as *mut u8;
+            unsafe { *result_length = len };
+            ptr
+        }
+        Ok(Err(_)) | Err(_) => std::ptr::null_mut(),
+    }
+}
+
+/// Free a buffer previously returned by [`wuff_woff2_decode`].
+///
+/// # Safety
+///
+/// - `ptr` must either be null (in which case this is a no-op) or a pointer
+///   previously returned by [`wuff_woff2_decode`], with `length` being the
+///   value stored in `*result_length` by that call.
+/// - The buffer must not have already been freed.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wuff_woff2_free(ptr: *mut u8, length: usize) {
+    if ptr.is_null() {
+        return;
+    }
+    let slice = std::ptr::slice_from_raw_parts_mut(ptr, length);
+    drop(unsafe { Box::from_raw(slice) });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compute_final_size_null_and_short() {
+        unsafe {
+            assert_eq!(wuff_woff2_compute_final_size(std::ptr::null(), 0), 0);
+            let short = [0u8; 19];
+            assert_eq!(
+                wuff_woff2_compute_final_size(short.as_ptr(), short.len()),
+                0
+            );
+        }
+    }
+
+    #[test]
+    fn compute_final_size_reads_total_sfnt_size() {
+        let mut header = [0u8; 48];
+        header[16..20].copy_from_slice(&0x0001_2345u32.to_be_bytes());
+        unsafe {
+            assert_eq!(
+                wuff_woff2_compute_final_size(header.as_ptr(), header.len()),
+                0x0001_2345
+            );
+        }
+    }
+
+    #[test]
+    fn decode_invalid_data_returns_null() {
+        let garbage = [0u8; 64];
+        let mut len = usize::MAX;
+        let ptr = unsafe { wuff_woff2_decode(garbage.as_ptr(), garbage.len(), &mut len) };
+        assert!(ptr.is_null());
+        assert_eq!(len, 0);
+    }
+
+    #[test]
+    fn free_null_is_noop() {
+        unsafe { wuff_woff2_free(std::ptr::null_mut(), 0) };
+    }
+}


### PR DESCRIPTION
This adds a C/C++ api that is compatible with the C++ `woff2` library as a new `wuff-capi` crate on top of the core `wuff` crate.

Generated with Fable High. Manual review ongoing.

Note: the C headers are very similar to the C headers from the original C library (as one would expect for a drop-in API compatible implementation), as viewing the diff between the two is helpful for review.