### PR TITLE
Eliminate usage of the `arrayvec` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,12 +15,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
-name = "arrayvec"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,7 +478,6 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 name = "wuff"
 version = "0.2.7"
 dependencies = [
- "arrayvec",
  "brotli-decompressor",
  "bytes",
  "flate2",

--- a/wuff/Cargo.toml
+++ b/wuff/Cargo.toml
@@ -31,7 +31,6 @@ font_compression_bin = []
 debug = []
 
 [dependencies]
-arrayvec = { version = "0.7.6", default-features = false }
 bytes = { version = "1.10.1", default-features = false }
 # `brotli` is no_std-compatible: we drive `brotli-decompressor` with our own
 # `alloc`-backed allocator, so its `std` default feature is disabled.

--- a/wuff/src/variable_length.rs
+++ b/wuff/src/variable_length.rs
@@ -8,7 +8,6 @@
 
 use alloc::vec::Vec;
 
-use arrayvec::ArrayVec;
 use bytes::Buf;
 
 use crate::error::{WuffErr, bail, bail_if};
@@ -46,22 +45,31 @@ fn Size255UShort(value: u16) -> usize {
     }
 }
 
-fn Write255UShort(value: i32) -> ArrayVec<u8, 3> {
-    let mut packed: ArrayVec<u8, 3> = ArrayVec::new();
-    if value < 253 {
-        packed.push(value as u8);
-    } else if value < 506 {
-        packed.push(255);
-        packed.push((value - 253) as u8);
-    } else if value < 762 {
-        packed.push(254);
-        packed.push((value - 506) as u8);
-    } else {
-        packed.push(253);
-        packed.push((value >> 8) as u8);
-        packed.push((value & 0xff) as u8);
+// Last byte is the length
+#[derive(Copy, Clone)]
+struct UShort255([u8; 4]);
+
+impl<'a> IntoIterator for &'a UShort255 {
+    type Item = u8;
+    type IntoIter = core::iter::Copied<core::slice::Iter<'a, u8>>;
+
+    #[inline(always)]
+    fn into_iter(self) -> Self::IntoIter {
+        let len = self.0[3] as usize;
+        self.0[0..len].iter().copied()
     }
-    packed
+}
+
+fn Write255UShort(value: i32) -> UShort255 {
+    if value < 253 {
+        UShort255([value as u8, 0, 0, 1])
+    } else if value < 506 {
+        UShort255([255, (value - 253) as u8, 0, 2])
+    } else if value < 762 {
+        UShort255([254, (value - 506) as u8, 0, 2])
+    } else {
+        UShort255([253, (value >> 8) as u8, (value & 0xff) as u8, 3])
+    }
 }
 
 pub(crate) fn Store255UShort(val: i32, offset: &mut usize, dst: &mut [u8]) {

--- a/wuff/src/woff/glyf_decoder.rs
+++ b/wuff/src/woff/glyf_decoder.rs
@@ -1,6 +1,5 @@
 use alloc::{vec, vec::Vec};
 
-use arrayvec::ArrayVec;
 use bytes::{Buf, BufMut};
 
 use crate::{
@@ -88,25 +87,27 @@ impl GlyfDecoder<'_> {
         bail_if!(offset > data.len());
 
         // Invariant from here on: data_size >= offset
-        let mut substreams: ArrayVec<&[u8], NUM_SUB_STREAMS> = ArrayVec::new();
-        for _ in 0..NUM_SUB_STREAMS {
+        let mut read_stream = || {
             let substream_size: usize = input.try_get_u32()? as usize;
             bail_if!(substream_size > data.len() - offset);
-            substreams.push(&data[offset..(offset + substream_size)]);
+            let substream_range = offset..(offset + substream_size);
             offset += substream_size;
-        }
+
+            Ok(&data[substream_range])
+        };
+
+        let n_contour_stream = read_stream()?;
+        let n_points_stream = read_stream()?;
+        let flag_stream = read_stream()?;
+        let glyph_stream = read_stream()?;
+        let composite_stream = read_stream()?;
+        let unsplit_bbox_stream = read_stream()?;
+        let instruction_stream = read_stream()?;
 
         // Safe because num_glyphs is bounded
         let bitmap_length: usize = ((num_glyphs as usize + 31) >> 5) << 2;
-        bail_if!(bitmap_length > substreams[5].len());
-
-        let n_contour_stream = substreams[0];
-        let n_points_stream = substreams[1];
-        let flag_stream = substreams[2];
-        let glyph_stream = substreams[3];
-        let composite_stream = substreams[4];
-        let (bbox_bitmap, bbox_stream) = substreams[5].split_at(bitmap_length);
-        let instruction_stream = substreams[6];
+        bail_if!(bitmap_length > unsplit_bbox_stream.len());
+        let (bbox_bitmap, bbox_stream) = unsplit_bbox_stream.split_at(bitmap_length);
 
         let mut overlap_bitmap: Option<&[u8]> = None;
         if has_overlap_bitmap {


### PR DESCRIPTION
Replace with plain arrays