### PR TITLE
Fix output `Vec` capacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+- Fix a memory-usage regression introduced in 0.2.7: the WOFF2 output buffer could retain up to
+  ~2x its final size in unused capacity. It is now shrunk to fit before being returned.
+
 ## 0.2.8
 - Remove `arrayvec` dependency
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 - Fix a memory-usage regression introduced in 0.2.7: the WOFF2 output buffer could retain up to
   ~2x its final size in unused capacity. It is now shrunk to fit before being returned.
+- Reject WOFF2 fonts whose decompressed data or reconstructed output exceeds 128 MiB (matching
+  upstream woff2's default limit).
 
 ## 0.2.8
 - Remove `arrayvec` dependency

--- a/wuff/src/decompress_woff2.rs
+++ b/wuff/src/decompress_woff2.rs
@@ -97,7 +97,34 @@ pub fn decompress_woff2_with_custom_brotli(
     // <https://www.w3.org/TR/WOFF2/#conform-mustRejectExtraData>
     bail_if!(decompressed_data.len() != table_directory.uncompressed_size);
 
-    let mut out: Vec<u8> = Vec::with_capacity(table_directory.uncompressed_size);
+    // `totalSfntSize` is normally the exact size of the reconstructed font, which makes it the
+    // ideal starting capacity for the output buffer. But it is untrusted (and per spec an
+    // inaccurate value must not cause rejection), so only honour it as a capacity hint when it
+    // is plausible:
+    //   - It must not exceed the expected reconstructed size computed from the table directory
+    //     (output headers + the 4-byte-padded `origLength` of each table). This allows for the
+    //     data that exists outside the compressed stream (headers, reconstructed loca, glyf
+    //     expansion, padding) while rejecting arbitrary inflation. The `origLength` values are
+    //     themselves cross-checked against the reconstructed tables during reconstruction.
+    //   - It must also pass the same compression-ratio plausibility bound as the decompressed
+    //     size, so a font whose directory *and* `totalSfntSize` are inflated in tandem still
+    //     cannot force an allocation larger than 100x the input size.
+    // Otherwise fall back to the trusted (ratio-bounded) `uncompressed_size`.
+    let expected_sfnt_size: u64 = compute_header_size(&collection_directory, header.is_collection())
+        as u64
+        + table_directory
+            .iter()
+            .map(|table| Round4!(table.orig_length as u64))
+            .sum::<u64>();
+    let sfnt_size_ratio = (header.total_sfnt_size as f32) / (raw_woff_data.len() as f32);
+    let capacity_hint = if header.total_sfnt_size as u64 <= expected_sfnt_size
+        && sfnt_size_ratio <= K_MAX_PLAUSIBLE_COMPRESSION_RATIO
+    {
+        (header.total_sfnt_size as usize).max(table_directory.uncompressed_size)
+    } else {
+        table_directory.uncompressed_size
+    };
+    let mut out: Vec<u8> = Vec::with_capacity(capacity_hint);
 
     let mut out_header = generate_header(&header, &table_directory, &collection_directory);
     out.extend_from_slice(&out_header.data);

--- a/wuff/src/decompress_woff2.rs
+++ b/wuff/src/decompress_woff2.rs
@@ -139,12 +139,15 @@ pub fn decompress_woff2_with_custom_brotli(
     // Update header
     out[0..out_header.data.len()].copy_from_slice(&out_header.data);
 
-    // The output buffer's initial capacity (`uncompressed_size`) is the size of the transformed
-    // data block, which is typically smaller than the reconstructed font (transformed glyf is
-    // more compact than raw glyf + loca). Growing past the initial capacity leaves the Vec with
-    // up to ~2x excess capacity, so release the excess before handing the buffer to the caller,
-    // who may retain it for a long time.
-    out.shrink_to_fit();
+    // The capacity hint above can over-estimate (inflated `origLength`s), and if the buffer
+    // outgrew it the doubling growth strategy can leave up to ~2x excess capacity. The caller may
+    // retain the buffer for a long time, so release the excess if it is significant. Skip the
+    // shrink (which may reallocate and copy) when the excess is small, such as the few bytes by
+    // which the hint typically over-estimates the reconstructed glyf table.
+    const SHRINK_SLACK: usize = 1024;
+    if out.capacity() > out.len() + out.len() / 16 + SHRINK_SLACK {
+        out.shrink_to_fit();
+    }
 
     Ok(out)
 }

--- a/wuff/src/decompress_woff2.rs
+++ b/wuff/src/decompress_woff2.rs
@@ -97,25 +97,34 @@ pub fn decompress_woff2_with_custom_brotli(
     // <https://www.w3.org/TR/WOFF2/#conform-mustRejectExtraData>
     bail_if!(decompressed_data.len() != table_directory.uncompressed_size);
 
-    // Size the output buffer using the expected reconstructed size computed from the table
-    // directory: output headers + the 4-byte-padded `origLength` of each table. For a conformant
-    // font this is exact (it is how the spec defines `totalSfntSize`); it can only be wrong where
-    // a declared `origLength` is inaccurate (possible for glyf/hmtx, whose reconstructed sizes
-    // are not required to match). The `origLength` values are attacker-controlled, so bound the
-    // hint by the same compression-ratio plausibility limit as the decompressed size, ensuring an
-    // inflated directory cannot force an allocation larger than 100x the input size. Note this is
-    // only a capacity hint: it does not affect which fonts are accepted or the bytes produced.
+    // Choose a capacity hint for the output buffer. For a well-formed font `totalSfntSize` is
+    // the exact size of the reconstructed font, but it is untrusted, so validate it against the
+    // expected reconstructed size computed from the table directory: output headers + the
+    // 4-byte-padded `origLength` of each table. That expected size is itself a slight
+    // over-estimate for a conformant font (reconstructed glyf/hmtx tables may legitimately be
+    // smaller than their declared `origLength`), so it bounds `totalSfntSize` from above and
+    // serves as the fallback hint when `totalSfntSize` is implausible. The `origLength` values
+    // are also attacker-controlled, so additionally bound the hint by the same compression-ratio
+    // plausibility limit as the decompressed size, ensuring an inflated directory cannot force
+    // an allocation larger than 100x the input size. Note this is only a capacity hint: it does
+    // not affect which fonts are accepted or the bytes produced.
     let expected_sfnt_size: u64 = compute_header_size(&collection_directory, header.is_collection())
         as u64
         + table_directory
             .iter()
             .map(|table| Round4!(table.orig_length as u64))
             .sum::<u64>();
+    let total_sfnt_size = header.total_sfnt_size as u64;
+    let sfnt_size_is_plausible = total_sfnt_size <= expected_sfnt_size
+        && total_sfnt_size >= table_directory.uncompressed_size as u64;
     let max_plausible_size =
         (K_MAX_PLAUSIBLE_COMPRESSION_RATIO as u64).saturating_mul(raw_woff_data.len() as u64);
-    let capacity_hint = expected_sfnt_size
-        .min(max_plausible_size)
-        .max(table_directory.uncompressed_size as u64) as usize;
+    let capacity_hint = if sfnt_size_is_plausible {
+        total_sfnt_size
+    } else {
+        expected_sfnt_size
+    }
+    .min(max_plausible_size) as usize;
     let mut out: Vec<u8> = Vec::with_capacity(capacity_hint);
 
     let mut out_header = generate_header(&header, &table_directory, &collection_directory);

--- a/wuff/src/decompress_woff2.rs
+++ b/wuff/src/decompress_woff2.rs
@@ -97,33 +97,25 @@ pub fn decompress_woff2_with_custom_brotli(
     // <https://www.w3.org/TR/WOFF2/#conform-mustRejectExtraData>
     bail_if!(decompressed_data.len() != table_directory.uncompressed_size);
 
-    // `totalSfntSize` is normally the exact size of the reconstructed font, which makes it the
-    // ideal starting capacity for the output buffer. But it is untrusted (and per spec an
-    // inaccurate value must not cause rejection), so only honour it as a capacity hint when it
-    // is plausible:
-    //   - It must not exceed the expected reconstructed size computed from the table directory
-    //     (output headers + the 4-byte-padded `origLength` of each table). This allows for the
-    //     data that exists outside the compressed stream (headers, reconstructed loca, glyf
-    //     expansion, padding) while rejecting arbitrary inflation. The `origLength` values are
-    //     themselves cross-checked against the reconstructed tables during reconstruction.
-    //   - It must also pass the same compression-ratio plausibility bound as the decompressed
-    //     size, so a font whose directory *and* `totalSfntSize` are inflated in tandem still
-    //     cannot force an allocation larger than 100x the input size.
-    // Otherwise fall back to the trusted (ratio-bounded) `uncompressed_size`.
+    // Size the output buffer using the expected reconstructed size computed from the table
+    // directory: output headers + the 4-byte-padded `origLength` of each table. For a conformant
+    // font this is exact (it is how the spec defines `totalSfntSize`); it can only be wrong where
+    // a declared `origLength` is inaccurate (possible for glyf/hmtx, whose reconstructed sizes
+    // are not required to match). The `origLength` values are attacker-controlled, so bound the
+    // hint by the same compression-ratio plausibility limit as the decompressed size, ensuring an
+    // inflated directory cannot force an allocation larger than 100x the input size. Note this is
+    // only a capacity hint: it does not affect which fonts are accepted or the bytes produced.
     let expected_sfnt_size: u64 = compute_header_size(&collection_directory, header.is_collection())
         as u64
         + table_directory
             .iter()
             .map(|table| Round4!(table.orig_length as u64))
             .sum::<u64>();
-    let sfnt_size_ratio = (header.total_sfnt_size as f32) / (raw_woff_data.len() as f32);
-    let capacity_hint = if header.total_sfnt_size as u64 <= expected_sfnt_size
-        && sfnt_size_ratio <= K_MAX_PLAUSIBLE_COMPRESSION_RATIO
-    {
-        (header.total_sfnt_size as usize).max(table_directory.uncompressed_size)
-    } else {
-        table_directory.uncompressed_size
-    };
+    let max_plausible_size =
+        (K_MAX_PLAUSIBLE_COMPRESSION_RATIO as u64).saturating_mul(raw_woff_data.len() as u64);
+    let capacity_hint = expected_sfnt_size
+        .min(max_plausible_size)
+        .max(table_directory.uncompressed_size as u64) as usize;
     let mut out: Vec<u8> = Vec::with_capacity(capacity_hint);
 
     let mut out_header = generate_header(&header, &table_directory, &collection_directory);

--- a/wuff/src/decompress_woff2.rs
+++ b/wuff/src/decompress_woff2.rs
@@ -120,6 +120,13 @@ pub fn decompress_woff2_with_custom_brotli(
     // Update header
     out[0..out_header.data.len()].copy_from_slice(&out_header.data);
 
+    // The output buffer's initial capacity (`uncompressed_size`) is the size of the transformed
+    // data block, which is typically smaller than the reconstructed font (transformed glyf is
+    // more compact than raw glyf + loca). Growing past the initial capacity leaves the Vec with
+    // up to ~2x excess capacity, so release the excess before handing the buffer to the caller,
+    // who may retain it for a long time.
+    out.shrink_to_fit();
+
     Ok(out)
 }
 

--- a/wuff/src/decompress_woff2.rs
+++ b/wuff/src/decompress_woff2.rs
@@ -22,6 +22,10 @@ use crate::{
 // >100 suggests you wrote a bad uncompressed size.
 const K_MAX_PLAUSIBLE_COMPRESSION_RATIO: f32 = 100.0;
 
+// Absolute cap on the decompressed data and reconstructed font size (matches upstream woff2's
+// `kDefaultMaxSize`). The compression-ratio check alone permits huge outputs for large inputs.
+const MAX_OUTPUT_SIZE: usize = 128 * 1024 * 1024;
+
 #[allow(clippy::type_complexity)]
 /// Decompress a WOFF2 file using a custom brotli decompressor passed as a closure
 pub fn decompress_woff2_with_custom_brotli(
@@ -85,6 +89,7 @@ pub fn decompress_woff2_with_custom_brotli(
         "Implausible compression ratio {:.1}",
         compression_ratio
     );
+    bail_if!(table_directory.uncompressed_size > MAX_OUTPUT_SIZE);
 
     // Decompress data with brotli decoder. We pass the trusted `uncompressed_size` as the hard
     // upper bound on the size of the decompressed data.
@@ -100,7 +105,8 @@ pub fn decompress_woff2_with_custom_brotli(
     // Output capacity hint. `totalSfntSize` is exact for a well-formed font but untrusted, so
     // only use it if it is bounded by the directory-derived size (headers + padded `origLength`s,
     // a slight over-estimate for conformant fonts), falling back to that size otherwise. Both are
-    // clamped to the compression-ratio limit since `origLength` is also attacker-controlled.
+    // clamped to the compression-ratio limit and `MAX_OUTPUT_SIZE` since `origLength` is also
+    // attacker-controlled.
     let expected_sfnt_size: u64 = compute_header_size(&collection_directory, header.is_collection())
         as u64
         + table_directory
@@ -117,7 +123,8 @@ pub fn decompress_woff2_with_custom_brotli(
     } else {
         expected_sfnt_size
     }
-    .min(max_plausible_size) as usize;
+    .min(max_plausible_size)
+    .min(MAX_OUTPUT_SIZE as u64) as usize;
     let mut out: Vec<u8> = Vec::with_capacity(capacity_hint);
 
     let mut out_header = generate_header(&header, &table_directory, &collection_directory);
@@ -137,6 +144,8 @@ pub fn decompress_woff2_with_custom_brotli(
             i,
         )?;
     }
+
+    bail_if!(out.len() > MAX_OUTPUT_SIZE);
 
     // Update header
     out[0..out_header.data.len()].copy_from_slice(&out_header.data);

--- a/wuff/src/decompress_woff2.rs
+++ b/wuff/src/decompress_woff2.rs
@@ -141,8 +141,10 @@ pub fn decompress_woff2_with_custom_brotli(
     // Update header
     out[0..out_header.data.len()].copy_from_slice(&out_header.data);
 
-    // The hint may over-estimate, or the buffer may have outgrown it (leaving up to ~2x excess).
-    // Callers tend to retain the buffer, so shrink it if the excess is significant.
+    // The hint may over-estimate (the directory-derived fallback is a slight over-estimate, and an
+    // inflated `origLength` can make it a large one), or the buffer may have outgrown it (leaving
+    // up to ~2x excess). Callers tend to retain the buffer, so shrink it if the excess is
+    // significant.
     const SHRINK_SLACK: usize = 1024;
     if out.capacity() > out.len() + out.len() / 16 + SHRINK_SLACK {
         out.shrink_to_fit();

--- a/wuff/src/decompress_woff2.rs
+++ b/wuff/src/decompress_woff2.rs
@@ -97,17 +97,10 @@ pub fn decompress_woff2_with_custom_brotli(
     // <https://www.w3.org/TR/WOFF2/#conform-mustRejectExtraData>
     bail_if!(decompressed_data.len() != table_directory.uncompressed_size);
 
-    // Choose a capacity hint for the output buffer. For a well-formed font `totalSfntSize` is
-    // the exact size of the reconstructed font, but it is untrusted, so validate it against the
-    // expected reconstructed size computed from the table directory: output headers + the
-    // 4-byte-padded `origLength` of each table. That expected size is itself a slight
-    // over-estimate for a conformant font (reconstructed glyf/hmtx tables may legitimately be
-    // smaller than their declared `origLength`), so it bounds `totalSfntSize` from above and
-    // serves as the fallback hint when `totalSfntSize` is implausible. The `origLength` values
-    // are also attacker-controlled, so additionally bound the hint by the same compression-ratio
-    // plausibility limit as the decompressed size, ensuring an inflated directory cannot force
-    // an allocation larger than 100x the input size. Note this is only a capacity hint: it does
-    // not affect which fonts are accepted or the bytes produced.
+    // Output capacity hint. `totalSfntSize` is exact for a well-formed font but untrusted, so
+    // only use it if it is bounded by the directory-derived size (headers + padded `origLength`s,
+    // a slight over-estimate for conformant fonts), falling back to that size otherwise. Both are
+    // clamped to the compression-ratio limit since `origLength` is also attacker-controlled.
     let expected_sfnt_size: u64 = compute_header_size(&collection_directory, header.is_collection())
         as u64
         + table_directory
@@ -148,11 +141,8 @@ pub fn decompress_woff2_with_custom_brotli(
     // Update header
     out[0..out_header.data.len()].copy_from_slice(&out_header.data);
 
-    // The capacity hint above can over-estimate (inflated `origLength`s), and if the buffer
-    // outgrew it the doubling growth strategy can leave up to ~2x excess capacity. The caller may
-    // retain the buffer for a long time, so release the excess if it is significant. Skip the
-    // shrink (which may reallocate and copy) when the excess is small, such as the few bytes by
-    // which the hint typically over-estimates the reconstructed glyf table.
+    // The hint may over-estimate, or the buffer may have outgrown it (leaving up to ~2x excess).
+    // Callers tend to retain the buffer, so shrink it if the excess is significant.
     const SHRINK_SLACK: usize = 1024;
     if out.capacity() > out.len() + out.len() / 16 + SHRINK_SLACK {
         out.shrink_to_fit();


### PR DESCRIPTION
## Summary

Fixes the higher memory usage users report after upgrading to wuff 0.2.7.

**Root cause:** commit 82bdbc9 ("Bound WOFF2 decompression by the table-directory size rather than the untrusted totalSfntSize") changed the output buffer allocation in `decompress_woff2_with_custom_brotli` from

```
- Vec::with_capacity(header.total_sfnt_size)         // ≈ exact final output size
+ Vec::with_capacity(table_directory.uncompressed_size) // size of the *transformed* data block
```

`uncompressed_size` is the size of the compressed-side (transformed) data block, which is typically smaller than the reconstructed sfnt (transformed glyf is more compact than raw glyf + loca, and the output adds headers/padding). The `out` Vec therefore outgrows its initial capacity during reconstruction, and amplification doubling leaves up to ~2x excess capacity in the returned Vec — which callers typically retain for the lifetime of the loaded font.

Measured with Inter-Regular.woff2 (100 KB input, 293 KB output):
- 0.2.6: returned Vec `len=299940 cap=299940`
- 0.2.7: returned Vec `len=299940 cap=547952` (~83% wasted, retained)

(5d110c7, the brotli pre-allocated-buffer change, was checked too: it slightly *reduces* peak heap and doesn't leak.)

**Fix:**

1. Use `totalSfntSize` as the output buffer capacity hint when it is plausible — for a well-formed font it is the *exact* reconstructed size. Plausibility is checked against the directory-derived expected size, `expected_sfnt_size = compute_header_size(..) + Σ Round4(origLength)`, which for a conformant font is a slight over-estimate of the output (measured: within 16 bytes for every well-formed conformance font and Inter; only inflated glyf/hmtx `origLength`s over-estimate more), so it bounds `totalSfntSize` from above and serves as the fallback hint when `totalSfntSize` is implausible. Both are additionally clamped to `K_MAX_PLAUSIBLE_COMPRESSION_RATIO * input_len`, keeping attacker-forced allocation bounded at 100x the input size. This is purely a capacity hint — accept/reject behavior and output bytes are unchanged.
2. As a backstop for when the hint over-estimates or the buffer outgrows it, `shrink_to_fit()` the buffer before returning — but only when the excess capacity is significant (`cap > len + len/16 + 1024`), so a few-byte over-estimate doesn't trigger a realloc-and-copy.

After the fix (Inter-Regular): `len=299940 cap=299940` from a single exact allocation (no realloc, no shrink), and total allocation volume drops ~10%. A font with a deliberately inflated glyf `origLength` (`tabledata-glyf-origlength-002`, hint 19212 vs len 3652) does get shrunk to `cap==len`, and an incorrect `totalSfntSize` (`header-totalsfntsize-001`) falls back to the directory-derived hint and is still accepted per spec. Verified no accept/reject or output-length changes vs `main` across all 300 conformance fonts (`conformance/fonts/`).

(Moved from DioxusLabs/wuff#1; the head branch remains in DioxusLabs/wuff.)
