### PR TITLE
conformance: Fix crash from canonicalizing the not-yet-written report file

### DIFF
--- a/conformance/src/runner.rs
+++ b/conformance/src/runner.rs
@@ -395,9 +395,8 @@ pub fn run_and_report(
         counts[category_index(outcome)] += 1;
         writeln!(report, "{}: {}: {}", category, rel.display(), details).unwrap();
     }
-    let report_path = data_dir.join("report.txt");
+    let report_path = data_dir.canonicalize().unwrap().join("report.txt");
     fs::write(&report_path, &report).expect("failed to write report");
-    let report_path = report_path.canonicalize().unwrap();
 
     let [
         encode_fail,

--- a/conformance/src/runner.rs
+++ b/conformance/src/runner.rs
@@ -395,8 +395,9 @@ pub fn run_and_report(
         counts[category_index(outcome)] += 1;
         writeln!(report, "{}: {}: {}", category, rel.display(), details).unwrap();
     }
-    let report_path = data_dir.join("report.txt").canonicalize().unwrap();
+    let report_path = data_dir.join("report.txt");
     fs::write(&report_path, &report).expect("failed to write report");
+    let report_path = report_path.canonicalize().unwrap();
 
     let [
         encode_fail,


### PR DESCRIPTION
## Summary

`run_and_report` called `canonicalize()` on `<data-dir>/report.txt` before writing it, so the harness panicked with `NotFound` after running all tests whenever the file didn't already exist (e.g. a fresh `--data-dir`). Canonicalize the (always-existing) data dir instead and join the filename.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/f3ab4016cbff480daa6fd4e48991d856
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/f3ab4016cbff480daa6fd4e48991d856?variant=devin-insiders
Requested by: @nicoburns