### PR TITLE
Add `brotli-unsafe` feature flag for faster WOFF2 decompression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
+name = "alloc-stdlib"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,6 +42,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
  "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]

--- a/wuff/Cargo.toml
+++ b/wuff/Cargo.toml
@@ -26,6 +26,12 @@ required-features = ["brotli", "z"]
 [features]
 default = ["brotli", "z"]
 brotli = ["dep:brotli-decompressor"]
+# Enables `brotli-decompressor`'s `unsafe` feature, which removes array bounds
+# checks and buffer initialization inside the decoder (the public API stays
+# safe). ~5-10% faster WOFF2 decompression at the cost of unsafe code in the
+# dependency. NOTE: this feature is NOT no_std-compatible (it transitively
+# enables `alloc-stdlib`, which requires std).
+brotli-unsafe = ["brotli", "brotli-decompressor/std", "brotli-decompressor/unsafe"]
 z = ["dep:flate2"]
 font_compression_bin = []
 debug = []


### PR DESCRIPTION
## Summary

Adds an opt-in `brotli-unsafe` feature that forwards to `brotli-decompressor`'s `unsafe` feature: it switches the decoder's `fast!`/`fast_ref!`/`fast_inner!` macros to `get_unchecked` indexing and skips output-buffer initialization, while the public API remains safe (`unsafe` blocks are internal to the dependency).

Measured on the brotli stage in isolation (pinned single core): ~5–12% faster decompression — e.g. DejaVuSans' 258KB→637KB block went 4.08ms → 3.57ms. Since brotli is the majority of total `decompress_woff2` time, this is the cheapest available end-to-end win (~1–8% depending on font) with zero code changes — just a feature name and documentation.

Important caveat surfaced while wiring it up: `brotli-decompressor`'s `unsafe` feature unconditionally activates its optional `alloc-stdlib` dependency (`unsafe = ["alloc-no-stdlib/unsafe", "alloc-stdlib/unsafe"]`), and `alloc-stdlib` requires `std`. So this feature is **std-only** and will not build for no_std targets — noted in the feature doc comment. Also explicitly enables `brotli-decompressor/std` for the same reason.

Example: `wuff = { version = "0.2.9", features = ["brotli-unsafe"] }` (implies `brotli`).