### PR TITLE
Add brotli-c feature flag using Google's C brotli implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
         run: cargo check --workspace --all-targets
       - name: cargo check (no default features)
         run: cargo check -p wuff --no-default-features
+      - name: cargo check (brotli-c backend)
+        run: cargo check -p wuff --no-default-features --features brotli-c
 
   # Verify the crate still builds on its declared MSRV (see `rust-version` in
   # the Cargo.toml files; keep this in sync).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotlic"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f552f56f302af0006c32b50bfa2bdb4696fd6ba33c3ab9f6225fefdb1efdc680"
+dependencies = [
+ "brotlic-sys",
+]
+
+[[package]]
+name = "brotlic-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afdec5c62bc97b56349053cf66ba503af5c2448591be61c3ad70a5f11b57e574"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,6 +507,7 @@ name = "wuff"
 version = "0.2.9"
 dependencies = [
  "brotli-decompressor",
+ "brotlic",
  "bytes",
  "flate2",
 ]

--- a/wuff/Cargo.toml
+++ b/wuff/Cargo.toml
@@ -32,6 +32,12 @@ brotli = ["dep:brotli-decompressor"]
 # dependency. NOTE: this feature is NOT no_std-compatible (it transitively
 # enables `alloc-stdlib`, which requires std).
 brotli-unsafe = ["brotli", "brotli-decompressor/std", "brotli-decompressor/unsafe"]
+# Uses Google's C brotli library (via the `brotlic` crate) as the built-in WOFF2
+# decompressor instead of the pure-Rust `brotli-decompressor`. ~20-30% faster
+# brotli decompression, but requires a C toolchain at build time and links
+# non-Rust code. Takes precedence over `brotli`/`brotli-unsafe` when enabled
+# together.
+brotli-c = ["dep:brotlic"]
 z = ["dep:flate2"]
 font_compression_bin = []
 debug = []
@@ -41,6 +47,9 @@ bytes = { version = "1.10.1", default-features = false }
 # `brotli` is no_std-compatible: we drive `brotli-decompressor` with our own
 # `alloc`-backed allocator, so its `std` default feature is disabled.
 brotli-decompressor = { version = "5.0.0", optional = true, default-features = false }
+# `brotlic` (the `brotli-c` feature) binds Google's C brotli implementation. It
+# requires a C toolchain and is not no_std-compatible.
+brotlic = { version = "0.8", optional = true }
 # `flate2` (the `z` feature) is std-only, so this feature cannot be built for
 # no_std targets. no_std users can supply their own decompressor via
 # `decompress_woff1_with_custom_z`.

--- a/wuff/src/brotli.rs
+++ b/wuff/src/brotli.rs
@@ -1,8 +1,15 @@
-//! Built-in WOFF2 Brotli decompression, backed by `brotli-decompressor`.
+//! Built-in WOFF2 Brotli decompression.
 //!
-//! This module is only compiled when the `brotli` feature is enabled. It plugs the
-//! `brotli-decompressor` crate into [`decompress_woff2_with_custom_brotli`](crate::decompress_woff2_with_custom_brotli)
-//! using an `alloc`-backed allocator, so it works on `no_std` targets (with a global allocator).
+//! This module is compiled when the `brotli` or `brotli-c` feature is enabled and
+//! plugs a decompressor into [`decompress_woff2_with_custom_brotli`](crate::decompress_woff2_with_custom_brotli):
+//!
+//! - `brotli`: the pure-Rust `brotli-decompressor` crate, driven with an
+//!   `alloc`-backed allocator so it works on `no_std` targets (with a global
+//!   allocator). `brotli-unsafe` switches this backend to `brotli-decompressor`'s
+//!   faster unchecked implementation (std-only).
+//! - `brotli-c`: Google's C brotli library via the `brotlic` crate. Faster, but
+//!   requires a C toolchain and is not no_std-compatible. Takes precedence over
+//!   `brotli` when both features are enabled.
 
 use alloc::{boxed::Box, vec, vec::Vec};
 use core::error::Error;
@@ -14,20 +21,24 @@ use crate::decompress_woff2_with_custom_brotli;
 /// requires, so the decoder can allocate through the global allocator (`alloc`) rather
 /// than depending on `std`. This is the no_std equivalent of the crate's built-in
 /// `StandardAlloc` (which is only available behind its `std` feature).
+#[cfg(all(feature = "brotli", not(feature = "brotli-c")))]
 struct Rebox<T>(Box<[T]>);
 
+#[cfg(all(feature = "brotli", not(feature = "brotli-c")))]
 impl<T> Default for Rebox<T> {
     fn default() -> Self {
         Rebox(Vec::new().into_boxed_slice())
     }
 }
 
+#[cfg(all(feature = "brotli", not(feature = "brotli-c")))]
 impl<T> brotli_decompressor::SliceWrapper<T> for Rebox<T> {
     fn slice(&self) -> &[T] {
         &self.0
     }
 }
 
+#[cfg(all(feature = "brotli", not(feature = "brotli-c")))]
 impl<T> brotli_decompressor::SliceWrapperMut<T> for Rebox<T> {
     fn slice_mut(&mut self) -> &mut [T] {
         &mut self.0
@@ -35,8 +46,10 @@ impl<T> brotli_decompressor::SliceWrapperMut<T> for Rebox<T> {
 }
 
 /// Zero-sized allocator handing out `Rebox` cells backed by the global allocator.
+#[cfg(all(feature = "brotli", not(feature = "brotli-c")))]
 struct HeapAlloc;
 
+#[cfg(all(feature = "brotli", not(feature = "brotli-c")))]
 impl<T: Clone + Default> brotli_decompressor::Allocator<T> for HeapAlloc {
     type AllocatedMemory = Rebox<T>;
     fn alloc_cell(&mut self, len: usize) -> Rebox<T> {
@@ -45,6 +58,7 @@ impl<T: Clone + Default> brotli_decompressor::Allocator<T> for HeapAlloc {
     fn free_cell(&mut self, _data: Rebox<T>) {}
 }
 
+#[cfg(all(feature = "brotli", not(feature = "brotli-c")))]
 fn decompress_brotli(
     compressed_data: &[u8],
     expected_size: usize,
@@ -80,6 +94,33 @@ fn decompress_brotli(
     // padding bytes (up to 3, counted in `totalCompressedSize`) are harmless: the decoder reports
     // success at end-of-stream and simply leaves them unconsumed in the input.
     if !matches!(result, BrotliResult::ResultSuccess) || output_offset != expected_size {
+        return Err(Box::new(WuffErr::GenericError));
+    }
+
+    Ok(output)
+}
+
+/// Brotli decompression via Google's C implementation (the `brotlic` crate).
+#[cfg(feature = "brotli-c")]
+fn decompress_brotli(
+    compressed_data: &[u8],
+    expected_size: usize,
+) -> Result<Vec<u8>, Box<dyn Error>> {
+    use brotlic::decode::{BrotliDecoder, DecoderInfo};
+
+    // Allocate the output buffer once, up front, at exactly the (trusted) expected size.
+    // The decoder never writes past the end of the slice, so `expected_size` is a hard
+    // upper bound: a stream that would expand further reports `NeedsMoreOutput` rather
+    // than driving an unbounded allocation.
+    let mut output = vec![0u8; expected_size];
+    let result = BrotliDecoder::new()
+        .decompress(compressed_data, &mut output)
+        .map_err(|_| WuffErr::GenericError)?;
+
+    // Require a clean end-of-stream producing exactly `expected_size` bytes. Any trailing
+    // WOFF2 padding bytes (up to 3, counted in `totalCompressedSize`) are harmless: the
+    // decoder reports `Finished` at end-of-stream and simply leaves them unconsumed.
+    if !matches!(result.info, DecoderInfo::Finished) || result.bytes_written != expected_size {
         return Err(Box::new(WuffErr::GenericError));
     }
 

--- a/wuff/src/brotli/c.rs
+++ b/wuff/src/brotli/c.rs
@@ -1,0 +1,32 @@
+//! Brotli decompression via Google's C implementation (the `brotlic` crate).
+//! Requires a C toolchain at build time; not no_std-compatible.
+
+use alloc::{boxed::Box, vec, vec::Vec};
+use core::error::Error;
+
+use crate::WuffErr;
+
+pub(super) fn decompress_brotli(
+    compressed_data: &[u8],
+    expected_size: usize,
+) -> Result<Vec<u8>, Box<dyn Error>> {
+    use brotlic::decode::{BrotliDecoder, DecoderInfo};
+
+    // Allocate the output buffer once, up front, at exactly the (trusted) expected size.
+    // The decoder never writes past the end of the slice, so `expected_size` is a hard
+    // upper bound: a stream that would expand further reports `NeedsMoreOutput` rather
+    // than driving an unbounded allocation.
+    let mut output = vec![0u8; expected_size];
+    let result = BrotliDecoder::new()
+        .decompress(compressed_data, &mut output)
+        .map_err(|_| WuffErr::GenericError)?;
+
+    // Require a clean end-of-stream producing exactly `expected_size` bytes. Any trailing
+    // WOFF2 padding bytes (up to 3, counted in `totalCompressedSize`) are harmless: the
+    // decoder reports `Finished` at end-of-stream and simply leaves them unconsumed.
+    if !matches!(result.info, DecoderInfo::Finished) || result.bytes_written != expected_size {
+        return Err(Box::new(WuffErr::GenericError));
+    }
+
+    Ok(output)
+}

--- a/wuff/src/brotli/mod.rs
+++ b/wuff/src/brotli/mod.rs
@@ -1,0 +1,32 @@
+//! Built-in WOFF2 Brotli decompression.
+//!
+//! This module is compiled when the `brotli` or `brotli-c` feature is enabled and
+//! plugs a decompressor into [`decompress_woff2_with_custom_brotli`](crate::decompress_woff2_with_custom_brotli):
+//!
+//! - `brotli` (the [`rust`] submodule): the pure-Rust `brotli-decompressor` crate,
+//!   driven with an `alloc`-backed allocator so it works on `no_std` targets (with
+//!   a global allocator). `brotli-unsafe` switches this backend to
+//!   `brotli-decompressor`'s faster unchecked implementation (std-only).
+//! - `brotli-c` (the [`c`] submodule): Google's C brotli library via the `brotlic`
+//!   crate. Faster, but requires a C toolchain and is not no_std-compatible. Takes
+//!   precedence over `brotli` when both features are enabled.
+
+use alloc::vec::Vec;
+
+use crate::WuffErr;
+use crate::decompress_woff2_with_custom_brotli;
+
+#[cfg(feature = "brotli-c")]
+mod c;
+#[cfg(all(feature = "brotli", not(feature = "brotli-c")))]
+mod rust;
+
+#[cfg(feature = "brotli-c")]
+use c::decompress_brotli;
+#[cfg(all(feature = "brotli", not(feature = "brotli-c")))]
+use rust::decompress_brotli;
+
+/// Decompress a WOFF2 file using the built-in brotli decompressor
+pub fn decompress_woff2(raw_woff_data: &[u8]) -> Result<Vec<u8>, WuffErr> {
+    decompress_woff2_with_custom_brotli(raw_woff_data, &mut decompress_brotli)
+}

--- a/wuff/src/brotli/rust.rs
+++ b/wuff/src/brotli/rust.rs
@@ -1,44 +1,29 @@
-//! Built-in WOFF2 Brotli decompression.
-//!
-//! This module is compiled when the `brotli` or `brotli-c` feature is enabled and
-//! plugs a decompressor into [`decompress_woff2_with_custom_brotli`](crate::decompress_woff2_with_custom_brotli):
-//!
-//! - `brotli`: the pure-Rust `brotli-decompressor` crate, driven with an
-//!   `alloc`-backed allocator so it works on `no_std` targets (with a global
-//!   allocator). `brotli-unsafe` switches this backend to `brotli-decompressor`'s
-//!   faster unchecked implementation (std-only).
-//! - `brotli-c`: Google's C brotli library via the `brotlic` crate. Faster, but
-//!   requires a C toolchain and is not no_std-compatible. Takes precedence over
-//!   `brotli` when both features are enabled.
+//! Brotli decompression via the pure-Rust `brotli-decompressor` crate, driven with
+//! an `alloc`-backed allocator so it works on `no_std` targets.
 
 use alloc::{boxed::Box, vec, vec::Vec};
 use core::error::Error;
 
 use crate::WuffErr;
-use crate::decompress_woff2_with_custom_brotli;
 
 /// A `Box<[T]>` wrapper implementing the allocation traits that `brotli-decompressor`
 /// requires, so the decoder can allocate through the global allocator (`alloc`) rather
 /// than depending on `std`. This is the no_std equivalent of the crate's built-in
 /// `StandardAlloc` (which is only available behind its `std` feature).
-#[cfg(all(feature = "brotli", not(feature = "brotli-c")))]
 struct Rebox<T>(Box<[T]>);
 
-#[cfg(all(feature = "brotli", not(feature = "brotli-c")))]
 impl<T> Default for Rebox<T> {
     fn default() -> Self {
         Rebox(Vec::new().into_boxed_slice())
     }
 }
 
-#[cfg(all(feature = "brotli", not(feature = "brotli-c")))]
 impl<T> brotli_decompressor::SliceWrapper<T> for Rebox<T> {
     fn slice(&self) -> &[T] {
         &self.0
     }
 }
 
-#[cfg(all(feature = "brotli", not(feature = "brotli-c")))]
 impl<T> brotli_decompressor::SliceWrapperMut<T> for Rebox<T> {
     fn slice_mut(&mut self) -> &mut [T] {
         &mut self.0
@@ -46,10 +31,8 @@ impl<T> brotli_decompressor::SliceWrapperMut<T> for Rebox<T> {
 }
 
 /// Zero-sized allocator handing out `Rebox` cells backed by the global allocator.
-#[cfg(all(feature = "brotli", not(feature = "brotli-c")))]
 struct HeapAlloc;
 
-#[cfg(all(feature = "brotli", not(feature = "brotli-c")))]
 impl<T: Clone + Default> brotli_decompressor::Allocator<T> for HeapAlloc {
     type AllocatedMemory = Rebox<T>;
     fn alloc_cell(&mut self, len: usize) -> Rebox<T> {
@@ -58,8 +41,7 @@ impl<T: Clone + Default> brotli_decompressor::Allocator<T> for HeapAlloc {
     fn free_cell(&mut self, _data: Rebox<T>) {}
 }
 
-#[cfg(all(feature = "brotli", not(feature = "brotli-c")))]
-fn decompress_brotli(
+pub(super) fn decompress_brotli(
     compressed_data: &[u8],
     expected_size: usize,
 ) -> Result<Vec<u8>, Box<dyn Error>> {
@@ -98,36 +80,4 @@ fn decompress_brotli(
     }
 
     Ok(output)
-}
-
-/// Brotli decompression via Google's C implementation (the `brotlic` crate).
-#[cfg(feature = "brotli-c")]
-fn decompress_brotli(
-    compressed_data: &[u8],
-    expected_size: usize,
-) -> Result<Vec<u8>, Box<dyn Error>> {
-    use brotlic::decode::{BrotliDecoder, DecoderInfo};
-
-    // Allocate the output buffer once, up front, at exactly the (trusted) expected size.
-    // The decoder never writes past the end of the slice, so `expected_size` is a hard
-    // upper bound: a stream that would expand further reports `NeedsMoreOutput` rather
-    // than driving an unbounded allocation.
-    let mut output = vec![0u8; expected_size];
-    let result = BrotliDecoder::new()
-        .decompress(compressed_data, &mut output)
-        .map_err(|_| WuffErr::GenericError)?;
-
-    // Require a clean end-of-stream producing exactly `expected_size` bytes. Any trailing
-    // WOFF2 padding bytes (up to 3, counted in `totalCompressedSize`) are harmless: the
-    // decoder reports `Finished` at end-of-stream and simply leaves them unconsumed.
-    if !matches!(result.info, DecoderInfo::Finished) || result.bytes_written != expected_size {
-        return Err(Box::new(WuffErr::GenericError));
-    }
-
-    Ok(output)
-}
-
-/// Decompress a WOFF2 file using the built-in brotli decompressor
-pub fn decompress_woff2(raw_woff_data: &[u8]) -> Result<Vec<u8>, WuffErr> {
-    decompress_woff2_with_custom_brotli(raw_woff_data, &mut decompress_brotli)
 }

--- a/wuff/src/lib.rs
+++ b/wuff/src/lib.rs
@@ -8,7 +8,7 @@
 
 extern crate alloc;
 
-#[cfg(feature = "brotli")]
+#[cfg(any(feature = "brotli", feature = "brotli-c"))]
 mod brotli;
 mod decompress_woff1;
 mod decompress_woff2;
@@ -26,8 +26,8 @@ pub use error::WuffErr;
 #[cfg_attr(docsrs, doc(cfg(feature = "z")))]
 pub use decompress_woff1::decompress_woff1;
 
-#[cfg(feature = "brotli")]
-#[cfg_attr(docsrs, doc(cfg(feature = "brotli")))]
+#[cfg(any(feature = "brotli", feature = "brotli-c"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "brotli", feature = "brotli-c"))))]
 pub use brotli::decompress_woff2;
 
 const HEAD: Tag = Tag::new(b"head");


### PR DESCRIPTION
## Summary

Adds a `brotli-c` feature that routes the built-in `decompress_woff2` through Google's C brotli library (via `brotlic` → `brotlic-sys`) instead of the pure-Rust `brotli-decompressor`. This is the largest remaining decode-time win: brotli is the dominant cost, and the C implementation is ~20–30% faster than the Rust one on the decompression stage alone.

The C impl is selected in `decompress_brotli` by `#[cfg]`, gated in `wuff/src/brotli.rs`:

```rust
#[cfg(all(feature = "brotli", not(feature = "brotli-c")))]
fn decompress_brotli(...) { /* BrotliDecompressStream + HeapAlloc, unchanged */ }

#[cfg(feature = "brotli-c")]
fn decompress_brotli(compressed_data, expected_size) {
    let mut output = vec![0u8; expected_size];
    let result = BrotliDecoder::new().decompress(compressed_data, &mut output)?;
    // require DecoderInfo::Finished && bytes_written == expected_size
}
```

Same safety contract as the Rust path: `expected_size` (the trusted, table-directory-derived `uncompressed_size`) is a hard bound — the decoder reports `NeedsMoreOutput` rather than overflowing, and we require end-of-stream + exact size. Trailing WOFF2 padding bytes are left unconsumed, as before.

Feature semantics: `brotli-c` does not imply `brotli` (no need to link the Rust decoder); `decompress_woff2` and the `brotli` module are now gated on `any(feature = "brotli", feature = "brotli-c")`. When both are enabled, `brotli-c` wins and the `brotli-decompressor`-specific code (`Rebox`/`HeapAlloc`) is cfg'd out. Requires a C toolchain; not no_std-compatible.

## Benchmark (end-to-end `decompress_woff2`, 11 fonts, pinned core, interleaved min-of-N)

| Font | brotli (safe) | brotli-unsafe | brotli-c |
|---|---|---|---|
| DejaVuSans | 6.81ms | 6.87ms (1.01x) | **6.29ms (0.92x)** |
| NotoNaskhArabic | 1.88ms | 1.89ms (1.01x) | **1.69ms (0.90x)** |
| Inter | 2.53ms | 2.55ms (1.01x) | **2.30ms (0.91x)** |
| NotoJP.0 | 0.93ms | 0.93ms (1.01x) | **0.87ms (0.94x)** |
| geomean, 11 fonts | — | ~1.01x | **~0.92x** |

Isolated brotli-stage numbers are bigger (~28% on DejaVuSans) since wuff-side reconstruction is unchanged. Notably `brotli-unsafe` is ~1% end-to-end — wuff already pre-sizes the output buffer, which is where most of `unsafe`'s gains (skipping buffer init) were coming from; `brotli-c` gets the full decoder speedup.

## Correctness

Output byte-identical to the safe backend on all 299 wpt conformance fonts (including identical rejection of invalid files) and 11 real fonts. CI: added a `cargo check --features brotli-c` step.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/9a4cce3edbc84cb0a9ef08c57eb79b3d
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/9a4cce3edbc84cb0a9ef08c57eb79b3d?variant=devin-insiders
Requested by: @nicoburns